### PR TITLE
Fix names of IDs in structures

### DIFF
--- a/src/structures/ApplicationCommand.ts
+++ b/src/structures/ApplicationCommand.ts
@@ -3,7 +3,7 @@ import { snowflake } from "./Snowflake";
 
 export type ApplicationCommand = {
   id: snowflake;
-  applicationId: snowflake;
+  application_id: snowflake;
   name: string;
   description: string;
   options: ApplicationCommandOption[];

--- a/src/structures/Interaction.ts
+++ b/src/structures/Interaction.ts
@@ -17,8 +17,8 @@ export type Interaction = ApplicationCommand | {
   id: snowflake;
   type: Exclude<InteractionType, InteractionType.APPLICATION_COMMAND>;
   data?: ApplicationCommandInteractionData;
-  guildId: snowflake;
-  channelId: snowflake;
+  guild_id: snowflake;
+  channel_id: snowflake;
   member: GuildMember;
   token: string;
 };


### PR DESCRIPTION
Discord API expects fields like "application_id" instead of "applicationId"