### PR TITLE
Add builder API for commands and options

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -14,6 +14,7 @@ export class CommandBuilder {
     if (name.length < 3 || name.length > 32) {
       throw new Error("Command names must be between 3 and 32 characters");
     }
+    this.options = [];
     this.name = name;
     return this;
   }

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,0 +1,206 @@
+import {
+  ApplicationCommandOption,
+  ApplicationCommandOptionChoice,
+  ApplicationCommandOptionType,
+  PartialApplicationCommand,
+} from "./structures";
+
+export class CommandBuilder {
+  private name: string;
+  private description: string;
+  private options: ApplicationCommandOption[];
+
+  public setName(name: string): CommandBuilder {
+    if (name.length < 3 || name.length > 32) {
+      throw new Error("Command names must be between 3 and 32 characters");
+    }
+    this.name = name;
+    return this;
+  }
+
+  public setDescription(description: string): CommandBuilder {
+    if (description.length < 1 || description.length > 100) {
+      throw new Error(
+        "Command descriptions must be between 1 and 100 characters"
+      );
+    }
+    this.description = description;
+    return this;
+  }
+
+  public addOption(option: ApplicationCommandOption): CommandBuilder {
+    this.options.push(option);
+    return this;
+  }
+
+  public build(): PartialApplicationCommand {
+    return {
+      name: this.name,
+      description: this.description,
+      options: this.options,
+    };
+  }
+}
+
+export class SubcommandBuilder {
+  type: ApplicationCommandOptionType = ApplicationCommandOptionType.SUB_COMMAND;
+  name: string;
+  description: string;
+  default?: boolean;
+  required?: boolean;
+  options: ApplicationCommandOption[];
+
+  public setName(name: string): SubcommandBuilder {
+    if (name.length < 3 || name.length > 32) {
+      throw new Error("Subcommand names must be between 3 and 32 characters");
+    }
+    this.name = name;
+    return this;
+  }
+
+  public setDescription(description: string): SubcommandBuilder {
+    if (description.length < 1 || description.length > 100) {
+      throw new Error(
+        "Subcommand descriptions must be between 1 and 100 characters"
+      );
+    }
+    this.description = description;
+    return this;
+  }
+
+  public setDefault(def: boolean): SubcommandBuilder {
+    this.default = def;
+    return this;
+  }
+
+  public setRequired(required: boolean): SubcommandBuilder {
+    this.required = required;
+    return this;
+  }
+
+  public addOption(option: ApplicationCommandOption): SubcommandBuilder {
+    if (
+      option.type === ApplicationCommandOptionType.SUB_COMMAND ||
+      option.type === ApplicationCommandOptionType.SUB_COMMAND_GROUP
+    ) {
+      throw new Error(
+        "Subcommands can not have subcommands or subcommand groups as options"
+      );
+    }
+    this.options.push(option);
+    return this;
+  }
+
+  public build(): ApplicationCommandOption {
+    return {
+      ...this,
+    };
+  }
+}
+
+export class SubcommandGroupBuilder {
+  type: ApplicationCommandOptionType =
+    ApplicationCommandOptionType.SUB_COMMAND_GROUP;
+  name: string;
+  description: string;
+  default?: boolean;
+  required?: boolean;
+  options: ApplicationCommandOption[];
+
+  public setName(name: string): SubcommandGroupBuilder {
+    if (name.length < 3 || name.length > 32) {
+      throw new Error("Group names must be between 3 and 32 characters");
+    }
+    this.name = name;
+    return this;
+  }
+
+  public setDescription(description: string): SubcommandGroupBuilder {
+    if (description.length < 1 || description.length > 100) {
+      throw new Error(
+        "Group descriptions must be between 1 and 100 characters"
+      );
+    }
+    this.description = description;
+    return this;
+  }
+
+  public setDefault(def: boolean): SubcommandGroupBuilder {
+    this.default = def;
+    return this;
+  }
+
+  public setRequired(required: boolean): SubcommandGroupBuilder {
+    this.required = required;
+    return this;
+  }
+
+  public addOption(option: ApplicationCommandOption): SubcommandGroupBuilder {
+    if (option.type !== ApplicationCommandOptionType.SUB_COMMAND) {
+      throw new Error("Children of subcommand groups must be subcommands");
+    }
+    this.options.push(option);
+    return this;
+  }
+
+  public build(): ApplicationCommandOption {
+    return {
+      ...this,
+    };
+  }
+}
+
+export class ApplicationCommandOptionBuilder {
+  type: ApplicationCommandOptionType;
+  name: string;
+  description: string;
+  default?: boolean;
+  required?: boolean;
+  choices?: ApplicationCommandOptionChoice[];
+
+  public setType(
+    type: ApplicationCommandOptionType
+  ): ApplicationCommandOptionBuilder {
+    this.type = type;
+    return this;
+  }
+
+  public setName(name: string): ApplicationCommandOptionBuilder {
+    if (name.length < 3 || name.length > 32) {
+      throw new Error("Option names must be between 3 and 32 characters");
+    }
+    this.name = name;
+    return this;
+  }
+
+  public setDescription(description: string): ApplicationCommandOptionBuilder {
+    if (description.length < 1 || description.length > 100) {
+      throw new Error(
+        "Option descriptions must be between 1 and 100 characters"
+      );
+    }
+    this.description = description;
+    return this;
+  }
+
+  public setDefault(def: boolean): ApplicationCommandOptionBuilder {
+    this.default = def;
+    return this;
+  }
+
+  public setRequired(required: boolean): ApplicationCommandOptionBuilder {
+    this.required = required;
+    return this;
+  }
+
+  public addChoice(choice: ApplicationCommandOptionChoice) {
+    this.choices.push(choice);
+    return this;
+  }
+
+  public build(): ApplicationCommandOption {
+    return {
+      ...this,
+    };
+  }
+}

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -10,11 +10,14 @@ export class CommandBuilder {
   private description: string;
   private options: ApplicationCommandOption[];
 
+  constructor() {
+    this.options = [];
+  }
+
   public setName(name: string): CommandBuilder {
     if (name.length < 3 || name.length > 32) {
       throw new Error("Command names must be between 3 and 32 characters");
     }
-    this.options = [];
     this.name = name;
     return this;
   }
@@ -50,6 +53,10 @@ export class SubcommandBuilder {
   default?: boolean;
   required?: boolean;
   options: ApplicationCommandOption[];
+
+  constructor() {
+    this.options = [];
+  }
 
   public setName(name: string): SubcommandBuilder {
     if (name.length < 3 || name.length > 32) {
@@ -108,6 +115,10 @@ export class SubcommandGroupBuilder {
   required?: boolean;
   options: ApplicationCommandOption[];
 
+  constructor() {
+    this.options = [];
+  }
+
   public setName(name: string): SubcommandGroupBuilder {
     if (name.length < 3 || name.length > 32) {
       throw new Error("Group names must be between 3 and 32 characters");
@@ -158,6 +169,10 @@ export class ApplicationCommandOptionBuilder {
   default?: boolean;
   required?: boolean;
   choices?: ApplicationCommandOptionChoice[];
+
+  constructor() {
+    this.choices = [];
+  }
 
   public setType(
     type: ApplicationCommandOptionType

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const DISCORD_ENDPOINT = "https://discord.com/api/v8/";
 const makeEndpoint = (endpoint) => `${DISCORD_ENDPOINT}${endpoint}`;
 
 export * from "./structures";
+export * from "./builders";
 
 export class DiscordInteractions {
   private publicKey: snowflake;


### PR DESCRIPTION
This PR adds a builder style API for commands and options. I split subcommands and subcommand groups into separate builders to do separate validation/formatting for the API since they're fundamentally different from building any other type of option. I haven't added tests yet as I wasn't sure which testing structure/framework you wanted to use. Closes issue #14